### PR TITLE
Add amrex as a submodule

### DIFF
--- a/.github/workflows/mflotests.yml
+++ b/.github/workflows/mflotests.yml
@@ -17,7 +17,6 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y --no-install-recommends \
         build-essential g++ gfortran libopenmpi-dev openmpi-bin
-        git clone https://github.com/AMReX-Codes/amrex
     - name: Build Regression
       working-directory: ./tests/Cartesian
       run: |
@@ -82,7 +81,6 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends ninja-build \
               cuda-command-line-tools-${{matrix.cuda_pkg}} cuda-compiler-${{matrix.cuda_pkg}} cuda-minimal-build-${{matrix.cuda_pkg}} cuda-nvml-dev-${{matrix.cuda_pkg}} cuda-nvtx-${{matrix.cuda_pkg}} ${{matrix.cuda_extra}}
-          git clone https://github.com/AMReX-Codes/amrex
       - name: Configure and build
         working-directory: ./tests/Cartesian
         run: |

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "amrex"]
+	path = amrex
+	url = https://github.com/ndeak/amrex.git
+	branch = cvode

--- a/README.md
+++ b/README.md
@@ -21,12 +21,15 @@ see Crowley et al.,Frontiers in Energy Research 10 (https://www.frontiersin.org/
 
 
 # Build instructions
-
+* Mesoflow uses submodules, please clone with git clone --recursive https://github.com/NREL/mesoflow.git (or update your existing clone with git submodule update --init --recursive)
 * gcc and an MPI library (openMPI/MPICH) for CPU builds. cuda-11.0 is also required for GPU builds
-* This solver depends on the AMReX library - clone from https://github.com/AMReX-Codes/amrex
-* Set AMREX_HOME to the path of amrex (e.g. $export AMREX_HOME=/path/to/amrex
+* This tool depends on the AMReX library - which is included as a submodule
 * go to any of the test cases in tests or model folder (e.g. cd models/blockCatalyst1d)
 * build executable using the GNUMakefile - do $make for CPU build or do $make USE_CUDA=TRUE for GPU build
+* To enable implicit chemistry, this solver also requires SUNDIALS, please download the latest release (SUNDIALS v xyz)
+from (https://computing.llnl.gov/projects/sundials/sundials-software) and follow the installation instructions in
+(https://sundials.readthedocs.io/en/latest/Install_link.html). Compile with $make USE_SUNDIALS=TRUE after setting
+the appropriate installation path as SUNDIALS_ROOT in either the shell or in the GNUmakefile.
 
 # Run instructions
 

--- a/models/Make.mflo
+++ b/models/Make.mflo
@@ -1,4 +1,4 @@
-AMREX_HOME ?= ../../../amrex
+AMREX_HOME ?= ../../amrex
 MFLO_HOME  ?= ../../../mesoflow
 
 TOP := $(MFLO_HOME)


### PR DESCRIPTION
Add amrex as a submodule to enable cvode integration. The submodule is currently pointing to a fork for amrex, it will be changed when the cvode changes are merged to the main repo.