### PR TITLE
Adding dependabot to create a monthly PR updating the amrex submodule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+
+updates:
+  - package-ecosystem: gitsubmodule
+    schedule:
+        interval: "monthly"
+    directory: /
+    allow:
+      - dependency-name: "submods/amrex"


### PR DESCRIPTION
Create a PR once a month to update the amrex submodule using [dependabot](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#about-dependabot-and-github-actions). If this PR doesn't get approved, it will auto-delete a create a fresh PR next month.

This can be further automated (if desired) to auto-merge the PR after the CI tests pass. 